### PR TITLE
Added Nextion display

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -417,3 +417,9 @@ ModMeshStep:
   api: 3.0
   author: Miha Zivkovic
   repo_url: https://github.com/exoticatom/ModMashStep.git
+
+NextionDisplay:
+  description: Connect a Nextion 3.5" display, shows charts of selcted kettle/fermenter, watch up to 4 kettle at once
+  api: 3.0
+  author: Jan Battermann
+  repo_url: https://github.com/JamFfm/NEXTIONDisplay.git


### PR DESCRIPTION
Have a look at the GIT Page of the addon.
Basically it shows some CBPi3 data on a Nextion Display via Serial Connection.